### PR TITLE
Create report file and required dirs before writing

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>net.jonathangiles.tools</groupId>
         <artifactId>whitelistgenerator-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <groupId>net.jonathangiles.tools</groupId>
     <artifactId>whitelistgenerator-core</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 
     <name>Whitelist Generator - Core</name>
     <description>A tool to generate a report containing all whitelisted dependencies across a multi-module maven project</description>

--- a/core/src/main/java/net/jonathangiles/tools/maven/whitelistgenerator/report/JSONReport.java
+++ b/core/src/main/java/net/jonathangiles/tools/maven/whitelistgenerator/report/JSONReport.java
@@ -3,7 +3,9 @@ package net.jonathangiles.tools.maven.whitelistgenerator.report;
 import com.google.gson.GsonBuilder;
 import net.jonathangiles.tools.maven.whitelistgenerator.model.Result;
 
+import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.nio.file.Path;
 
 public class JSONReport implements Reporter {
@@ -14,17 +16,33 @@ public class JSONReport implements Reporter {
     }
 
     @Override
-    public void report(Result result, Path reportFile) {
-        try (FileWriter writer = new FileWriter(reportFile.toFile()))  {
+    public void report(Result result, Path reportFilePath) {
+        FileWriter writer = null;
+        try {
+            File reportFile = reportFilePath.toFile();
+            if (!reportFile.exists()) {
+                System.out.println("Creating file " + reportFile.getAbsolutePath());
+                reportFile.getParentFile().mkdirs();
+                reportFile.createNewFile();
+            }
+            writer = new FileWriter(reportFile);
             new GsonBuilder()
                     .setPrettyPrinting()
                     .excludeFieldsWithoutExposeAnnotation()
                     .create()
                     .toJson(result, writer);
 
-            System.out.println("JSON report written to " + reportFile);
+            System.out.println("JSON report written to " + reportFilePath);
         } catch (Exception e) {
             e.printStackTrace();
+        } finally {
+            if (writer != null) {
+                try {
+                    writer.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
         }
     }
 }

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.jonathangiles.tools</groupId>
         <artifactId>whitelistgenerator-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <name>Whitelist Generator - Maven Plugin</name>
@@ -16,7 +16,7 @@
 
     <groupId>net.jonathangiles.tools</groupId>
     <artifactId>whitelistgenerator-maven-plugin</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>maven-plugin</packaging>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.jonathangiles.tools</groupId>
     <artifactId>whitelistgenerator-parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>pom</packaging>
 
     <name>Whitelist Generator - Parent</name>


### PR DESCRIPTION
Depending on when this plugin is run, the target directory may not have already been created resulting in `FileNotFoundException`. This PR checks for the existence of report file and creates one (with necessary parent directories) if it doesn't exist before writing the report.